### PR TITLE
Make handles clonable regardless of Format parameter and add tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Make write handles clone regardless of their generic parameters.
+
 ## 0.5.0-alpha2 - 2021-09-22
 ### Changed
 - Implement `Clone` for the write handles of generated interfaces.

--- a/macros-tests/tests/camera.rs
+++ b/macros-tests/tests/camera.rs
@@ -1,5 +1,6 @@
 use assert2::{let_assert, assert};
 use fizyr_rpc::{UnixStreamPeer, UnixStreamTransport};
+use fizyr_rpc::util::format::Format;
 
 use macros_tests::{camera, Image, Json, RecordRequest, RecordState};
 
@@ -77,4 +78,19 @@ async fn record() {
 	drop(client);
 
 	assert!(let Ok(()) = server.await);
+}
+
+#[allow(dead_code, clippy::all)]
+fn assert_client_clone<F: Format>(camera: camera::Client<F>) {
+	let _ = camera.clone();
+}
+
+#[allow(dead_code, clippy::all)]
+fn assert_received_request_write_handle_clone<F: Format>(handle: camera::record::ReceivedRequestWriteHandle<F>) {
+	let _ = handle.clone();
+}
+
+#[allow(dead_code, clippy::all)]
+fn assert_sent_request_write_handle_clone<F: Format>(handle: camera::record::SentRequestWriteHandle<F>) {
+	let _ = handle.clone();
 }

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -43,7 +43,6 @@ fn generate_client(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, interf
 	let client_doc = format!("RPC client for the {} interface.", interface.name());
 	item_tokens.extend(quote! {
 		#[doc = #client_doc]
-		#[derive(Clone)]
 		pub struct Client<F: #fizyr_rpc::util::format::Format> {
 			peer: #fizyr_rpc::PeerWriteHandle<F::Body>,
 		}
@@ -53,6 +52,14 @@ fn generate_client(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, interf
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("peer", &self.peer)
 					.finish()
+			}
+		}
+
+		impl<F: #fizyr_rpc::util::format::Format> ::core::clone::Clone for Client<F> {
+			fn clone(&self) -> Self {
+				Self {
+					peer: self.peer.clone(),
+				}
 			}
 		}
 
@@ -426,7 +433,6 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 		}
 
 		#[doc = #write_handle_doc]
-		#[derive(Clone)]
 		pub struct SentRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
 			pub(super) request: #fizyr_rpc::SentRequestWriteHandle<F::Body>,
 		}
@@ -448,6 +454,14 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 					.field("service_id", &self.service_id())
 					// TODO: use finish_non_exhaustive when it hits stable
 					.finish()
+			}
+		}
+
+		impl<F: #fizyr_rpc::util::format::Format> ::core::clone::Clone for SentRequestWriteHandle<F> {
+			fn clone(&self) -> Self {
+				Self {
+					request: self.request.clone(),
+				}
 			}
 		}
 
@@ -832,7 +846,6 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		}
 
 		#[doc = #write_handle_doc]
-		#[derive(Clone)]
 		pub struct ReceivedRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
 			pub(super) request: #fizyr_rpc::ReceivedRequestWriteHandle<F::Body>,
 		}
@@ -854,6 +867,14 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 					.field("service_id", &self.service_id())
 					// TODO: use finish_non_exhaustive when it hits stable
 					.finish()
+			}
+		}
+
+		impl<F: #fizyr_rpc::util::format::Format> ::core::clone::Clone for ReceivedRequestWriteHandle<F> {
+			fn clone(&self) -> Self {
+				Self {
+					request: self.request.clone(),
+				}
 			}
 		}
 


### PR DESCRIPTION
`#[derive(Clone)]` is too picky when it comes to generic parameters that don't need to be cloned. So instead we use a manual clone implementation, and add some tests to guarantee that the handles can be clones regardless of the generic parameters.