### PR TITLE
Add interface introspection.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- [add][minor] Add runtime interface introspection.
 - [fix][minor] Remove the `Sized` restriction for the `EncodeBody` trait.
 - [impl][patch] Use `poll_write_vectored` in the TCP transport to write the header and body with a single syscall.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- [fix][minor] Remove the `Sized` restriction for the `EncodeBody` trait.
 - [impl][patch] Use `poll_write_vectored` in the TCP transport to write the header and body with a single syscall.
 
 # Version 0.5.0-alpha7 - 2022-01-10

--- a/macros-tests/src/camera.rs
+++ b/macros-tests/src/camera.rs
@@ -6,7 +6,7 @@ fizyr_rpc::interface! {
 	/// A camera server can represent many different types of cameras,
 	/// like a simple 2D camera, a 3D camera with or without RGB data,
 	/// or even a line scanner.
-	pub interface camera {
+	pub interface Camera {
 		/// Ping the server.
 		///
 		/// A succesful ping indicates that the server is running,
@@ -34,7 +34,7 @@ fizyr_rpc::interface! {
 
 pub mod camera_events {
 	fizyr_rpc::interface! {
-		pub interface camera_events {
+		pub interface CameraEvents {
 			/// Notifications whenever the camera changes record state.
 			stream 11 record_state: super::RecordState,
 		}

--- a/macros-tests/src/lib.rs
+++ b/macros-tests/src/lib.rs
@@ -13,10 +13,20 @@ impl<T: serde::de::DeserializeOwned> fizyr_rpc::util::format::DecodeBody<T> for 
 	}
 }
 
-impl<T: serde::Serialize> fizyr_rpc::util::format::EncodeBody<T> for Json {
+impl<T: serde::Serialize + ?Sized> fizyr_rpc::util::format::EncodeBody<T> for Json {
 	fn encode_body(value: &T) -> Result<fizyr_rpc::StreamBody, Box<dyn std::error::Error + Send>> {
 		serde_json::to_vec(value)
 			.map(fizyr_rpc::StreamBody::from)
 			.map_err(|e| Box::new(e) as _)
+	}
+}
+
+impl fizyr_rpc::introspection::IntrospectableFormat for Json {
+	type TypeInfo = &'static str;
+}
+
+impl<T: ?Sized> fizyr_rpc::introspection::FormatTypeInfo<T> for Json {
+	fn type_info() -> &'static str {
+		std::any::type_name::<T>()
 	}
 }

--- a/macros-tests/tests/camera.rs
+++ b/macros-tests/tests/camera.rs
@@ -138,11 +138,11 @@ fn interface_introspection_camera() {
 	let interface = camera::Interface::definition::<Json>();
 	assert!(interface.name == "Camera");
 	assert!(interface.doc == concat!(
-		" Interface to a camera server.\n",
+		"Interface to a camera server.\n",
 		"\n",
-		" A camera server can represent many different types of cameras,\n",
-		" like a simple 2D camera, a 3D camera with or without RGB data,\n",
-		" or even a line scanner.\n",
+		"A camera server can represent many different types of cameras,\n",
+		"like a simple 2D camera, a 3D camera with or without RGB data,\n",
+		"or even a line scanner.\n",
 	));
 
 	assert!(interface.services.len() == 2);
@@ -150,10 +150,10 @@ fn interface_introspection_camera() {
 	assert!(interface.services[0].name == "ping");
 	assert!(interface.services[0].service_id == 0);
 	assert!(interface.services[0].doc == concat!(
-		" Ping the server.\n",
+		"Ping the server.\n",
 		"\n",
-		" A succesful ping indicates that the server is running,\n",
-		" but it does not guarantee that it is connected to a camera.\n",
+		"A succesful ping indicates that the server is running,\n",
+		"but it does not guarantee that it is connected to a camera.\n",
 	));
 	assert!(interface.services[0].request_body == "()");
 	assert!(interface.services[0].response_body == "()");
@@ -162,31 +162,31 @@ fn interface_introspection_camera() {
 
 	assert!(interface.services[1].name == "record");
 	assert!(interface.services[1].service_id == 1);
-	assert!(interface.services[1].doc == " Record an image.\n");
+	assert!(interface.services[1].doc == "Record an image.\n");
 	assert!(interface.services[1].request_body == "macros_tests::camera::RecordRequest");
 	assert!(interface.services[1].response_body == "()");
 	assert!(interface.services[1].request_updates.len() == 1);
 	assert!(interface.services[1].request_updates[0].name == "cancel");
-	assert!(interface.services[1].request_updates[0].doc == " Cancel the recording prematurely.\n");
+	assert!(interface.services[1].request_updates[0].doc == "Cancel the recording prematurely.\n");
 	assert!(interface.services[1].request_updates[0].service_id == 10);
 	assert!(interface.services[1].request_updates[0].body == "macros_tests::camera::CancelReason");
 
 	assert!(interface.services[1].response_updates.len() == 2);
 	assert!(interface.services[1].response_updates[0].name == "state");
 	assert!(interface.services[1].response_updates[0].doc == concat!(
-		" Update sent by the server to notify the client about recording progress.\n",
+		"Update sent by the server to notify the client about recording progress.\n",
 		"\n",
-		" When the record state goes to `RecordState::Processing`,\n",
-		" the camera field of view may be obstructed by a robot again.\n",
+		"When the record state goes to `RecordState::Processing`,\n",
+		"the camera field of view may be obstructed by a robot again.\n",
 	));
 	assert!(interface.services[1].response_updates[0].service_id == 11);
 	assert!(interface.services[1].response_updates[0].body == "macros_tests::camera::RecordState");
 
 	assert!(interface.services[1].response_updates[1].name == "image");
 	assert!(interface.services[1].response_updates[1].doc == concat!(
-			" Update sent by the server when an image is available.\n",
+			"Update sent by the server when an image is available.\n",
 			"\n",
-			" The camera may send multiple image updates depending on the configuration.\n",
+			"The camera may send multiple image updates depending on the configuration.\n",
 	));
 	assert!(interface.services[1].response_updates[1].service_id == 12);
 	assert!(interface.services[1].response_updates[1].body == "macros_tests::camera::Image");
@@ -203,7 +203,7 @@ fn interface_introspection_camera_events() {
 	assert!(interface.streams.len() == 1);
 
 	assert!(interface.streams[0].name == "record_state");
-	assert!(interface.streams[0].doc == " Notifications whenever the camera changes record state.\n");
+	assert!(interface.streams[0].doc == "Notifications whenever the camera changes record state.\n");
 	assert!(interface.streams[0].service_id == 11);
 	assert!(interface.streams[0].body == "macros_tests::camera::RecordState");
 }

--- a/macros-tests/tests/camera.rs
+++ b/macros-tests/tests/camera.rs
@@ -132,3 +132,78 @@ fn assert_received_request_write_handle_clone<F: Format>(handle: camera::record:
 fn assert_sent_request_write_handle_clone<F: Format>(handle: camera::record::SentRequestWriteHandle<F>) {
 	let _ = handle.clone();
 }
+
+#[test]
+fn interface_introspection_camera() {
+	let interface = camera::Interface::definition::<Json>();
+	assert!(interface.name == "Camera");
+	assert!(interface.doc == concat!(
+		" Interface to a camera server.\n",
+		"\n",
+		" A camera server can represent many different types of cameras,\n",
+		" like a simple 2D camera, a 3D camera with or without RGB data,\n",
+		" or even a line scanner.\n",
+	));
+
+	assert!(interface.services.len() == 2);
+
+	assert!(interface.services[0].name == "ping");
+	assert!(interface.services[0].service_id == 0);
+	assert!(interface.services[0].doc == concat!(
+		" Ping the server.\n",
+		"\n",
+		" A succesful ping indicates that the server is running,\n",
+		" but it does not guarantee that it is connected to a camera.\n",
+	));
+	assert!(interface.services[0].request_body == "()");
+	assert!(interface.services[0].response_body == "()");
+	assert!(interface.services[0].request_updates.len() == 0);
+	assert!(interface.services[0].response_updates.len() == 0);
+
+	assert!(interface.services[1].name == "record");
+	assert!(interface.services[1].service_id == 1);
+	assert!(interface.services[1].doc == " Record an image.\n");
+	assert!(interface.services[1].request_body == "macros_tests::camera::RecordRequest");
+	assert!(interface.services[1].response_body == "()");
+	assert!(interface.services[1].request_updates.len() == 1);
+	assert!(interface.services[1].request_updates[0].name == "cancel");
+	assert!(interface.services[1].request_updates[0].doc == " Cancel the recording prematurely.\n");
+	assert!(interface.services[1].request_updates[0].service_id == 10);
+	assert!(interface.services[1].request_updates[0].body == "macros_tests::camera::CancelReason");
+
+	assert!(interface.services[1].response_updates.len() == 2);
+	assert!(interface.services[1].response_updates[0].name == "state");
+	assert!(interface.services[1].response_updates[0].doc == concat!(
+		" Update sent by the server to notify the client about recording progress.\n",
+		"\n",
+		" When the record state goes to `RecordState::Processing`,\n",
+		" the camera field of view may be obstructed by a robot again.\n",
+	));
+	assert!(interface.services[1].response_updates[0].service_id == 11);
+	assert!(interface.services[1].response_updates[0].body == "macros_tests::camera::RecordState");
+
+	assert!(interface.services[1].response_updates[1].name == "image");
+	assert!(interface.services[1].response_updates[1].doc == concat!(
+			" Update sent by the server when an image is available.\n",
+			"\n",
+			" The camera may send multiple image updates depending on the configuration.\n",
+	));
+	assert!(interface.services[1].response_updates[1].service_id == 12);
+	assert!(interface.services[1].response_updates[1].body == "macros_tests::camera::Image");
+}
+
+#[test]
+fn interface_introspection_camera_events() {
+	use camera::camera_events;
+
+	let interface = camera_events::Interface::definition::<Json>();
+	assert!(interface.name == "CameraEvents");
+	assert!(interface.doc == "");
+	assert!(interface.services.len() == 0);
+	assert!(interface.streams.len() == 1);
+
+	assert!(interface.streams[0].name == "record_state");
+	assert!(interface.streams[0].doc == " Notifications whenever the camera changes record state.\n");
+	assert!(interface.streams[0].service_id == 11);
+	assert!(interface.streams[0].body == "macros_tests::camera::RecordState");
+}

--- a/macros/src/interface/generate/interface_struct.rs
+++ b/macros/src/interface/generate/interface_struct.rs
@@ -1,20 +1,20 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::interface::parse::cooked::InterfaceDefinition;
+use crate::{interface::parse::cooked::{InterfaceDefinition, ServiceDefinition, UpdateDefinition, StreamDefinition}, util::WithSpan};
 
 /// Generate a struct representing the interface.
-///
-/// TODO: Add RPC introspection support to this struct.
-pub fn generate_interface_struct(item_tokens: &mut TokenStream, _fizyr_rpc: &syn::Ident, interface: &InterfaceDefinition) {
-	let mut doc = String::new();
-	for line in interface.doc() {
-		doc.push_str(&line.value);
-		doc.push('\n');
-	}
+pub fn generate_interface_struct(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, interface: &InterfaceDefinition) {
+	let name = interface.name().to_string();
+	let doc = to_doc_string(interface.doc());
 
 	let interface_doc = format!("Introspection for the {} RPC interface.", interface.name());
 	let visibility = interface.visibility();
+
+	let mut services_format_bounds = TokenStream::new();
+	let mut streams_format_bounds = TokenStream::new();
+	let service_definitions = service_definitions(&mut services_format_bounds, fizyr_rpc, interface.services());
+	let stream_definitions = stream_definitions(&mut streams_format_bounds, fizyr_rpc, interface.streams());
 
 	item_tokens.extend(quote! {
 		#[doc = #interface_doc]
@@ -24,10 +24,177 @@ pub fn generate_interface_struct(item_tokens: &mut TokenStream, _fizyr_rpc: &syn
 		}
 
 		impl Interface {
+			/// Get the name of the interface.
+			pub const fn name() -> &'static str {
+				#name
+			}
+
 			/// Get the documentation of the interface.
+			///
+			/// This string may contain rustdoc compatible markup.
 			pub const fn doc() -> &'static str {
 				#doc
 			}
+
+			/// Get the full interface definition.
+			///
+			/// The type information for message bodies depends on serialization format used.
+			pub fn definition<F>() -> #fizyr_rpc::introspection::InterfaceDefinition<F::TypeInfo>
+			where
+				F: #fizyr_rpc::introspection::IntrospectableFormat,
+				#services_format_bounds
+				#streams_format_bounds
+			{
+				#fizyr_rpc::introspection::InterfaceDefinition {
+					name: #name.to_string(),
+					doc: #doc.to_string(),
+					services: Self::services::<F>(),
+					streams: Self::streams::<F>(),
+				}
+			}
+
+			/// Get the list of services in the interface.
+			///
+			/// The type information for message bodies depends on serialization format used.
+			pub fn services<F>() -> ::std::vec::Vec<#fizyr_rpc::introspection::ServiceDefinition<F::TypeInfo>>
+			where
+				F: #fizyr_rpc::introspection::IntrospectableFormat,
+				#services_format_bounds
+			{
+				#service_definitions
+			}
+
+			/// Get the list of streams in the interface.
+			///
+			/// The type information for message bodies depends on serialization format used.
+			pub fn streams<F>() -> ::std::vec::Vec<#fizyr_rpc::introspection::StreamDefinition<F::TypeInfo>>
+			where
+				F: #fizyr_rpc::introspection::IntrospectableFormat,
+				#streams_format_bounds
+			{
+				#stream_definitions
+			}
 		}
 	})
+}
+
+/// Generate service definitions.
+///
+/// This function returns tokens that represent a vector of service definitions.
+///
+/// It also pushes required trait bounds to `format_bounds`.
+fn service_definitions(format_bounds: &mut TokenStream, fizyr_rpc: &syn::Ident, services: &[ServiceDefinition]) -> TokenStream {
+	let mut push_items = TokenStream::new();
+	for service in services {
+		let name = service.name().to_string();
+		let doc = to_doc_string(service.doc());
+		let service_id = service.service_id().value;
+		let request_type = service.request_type();
+		let response_type = service.response_type();
+		let request_updates = update_definitions(format_bounds, fizyr_rpc, service.request_updates());
+		let response_updates = update_definitions(format_bounds, fizyr_rpc, service.response_updates());
+
+		format_bounds.extend(quote! {
+			F: #fizyr_rpc::introspection::FormatTypeInfo<#request_type>,
+			F: #fizyr_rpc::introspection::FormatTypeInfo<#response_type>,
+		});
+
+		push_items.extend(quote! {
+			vector.push(#fizyr_rpc::introspection::ServiceDefinition {
+				name: #name.to_string(),
+				doc: #doc.to_string(),
+				service_id: #service_id,
+				request_body: <F as #fizyr_rpc::introspection::FormatTypeInfo<#request_type>>::type_info(),
+				response_body: <F as #fizyr_rpc::introspection::FormatTypeInfo<#response_type>>::type_info(),
+				request_updates: #request_updates,
+				response_updates: #response_updates,
+			});
+		})
+	}
+
+	let length = services.len();
+	quote!({
+		let mut vector = ::std::vec::Vec::with_capacity(#length);
+		#push_items
+		vector
+	})
+}
+
+/// Generate update definitions.
+///
+/// This function returns tokens that represent a vector of update definitions.
+///
+/// It also pushes required trait bounds to `format_bounds`.
+fn update_definitions(format_bounds: &mut TokenStream, fizyr_rpc: &syn::Ident, updates: &[UpdateDefinition]) -> TokenStream {
+	let mut push_items = TokenStream::new();
+	for update in updates {
+		let name = update.name().to_string();
+		let doc = to_doc_string(update.doc());
+		let service_id = update.service_id().value;
+		let body_type = update.body_type();
+
+		format_bounds.extend(quote! {
+			F: #fizyr_rpc::introspection::FormatTypeInfo<#body_type>,
+		});
+
+		push_items.extend(quote! {
+			vector.push(#fizyr_rpc::introspection::UpdateDefinition {
+				name: #name.to_string(),
+				doc: #doc.to_string(),
+				service_id: #service_id,
+				body: <F as #fizyr_rpc::introspection::FormatTypeInfo<#body_type>>::type_info(),
+			});
+		})
+	}
+
+	let length = updates.len();
+	quote!({
+		let mut vector = ::std::vec::Vec::with_capacity(#length);
+		#push_items
+		vector
+	})
+}
+
+/// Generate stream definitions.
+///
+/// This function returns tokens that represent a vector of stream definitions.
+///
+/// It also pushes required trait bounds to `format_bounds`.
+fn stream_definitions(format_bounds: &mut TokenStream, fizyr_rpc: &syn::Ident, streams: &[StreamDefinition]) -> TokenStream {
+	let mut push_items = TokenStream::new();
+	for streams in streams {
+		let name = streams.name().to_string();
+		let doc = to_doc_string(streams.doc());
+		let service_id = streams.service_id().value;
+		let body_type = streams.body_type();
+
+		format_bounds.extend(quote! {
+			F: #fizyr_rpc::introspection::FormatTypeInfo<#body_type>,
+		});
+
+		push_items.extend(quote! {
+			vector.push(#fizyr_rpc::introspection::StreamDefinition {
+				name: #name.to_string(),
+				doc: #doc.to_string(),
+				service_id: #service_id,
+				body: <F as #fizyr_rpc::introspection::FormatTypeInfo<#body_type>>::type_info(),
+			});
+		})
+	}
+
+	let length = streams.len();
+	quote!({
+		let mut vector = ::std::vec::Vec::with_capacity(#length);
+		#push_items
+		vector
+	})
+}
+
+fn to_doc_string(attrs: &[WithSpan<String>]) -> String {
+	let mut doc = String::new();
+	for line in attrs {
+		doc.push_str(&line.value);
+		doc.push('\n');
+	}
+	doc
 }

--- a/src/introspection.rs
+++ b/src/introspection.rs
@@ -1,0 +1,98 @@
+//! Support types and traits for runtime interface instrospection.
+//!
+//! These types and traits are used by generated interfaces from the [`interface!`] macro.
+//! Normally, you would only implement the traits for your own serialization format.
+//! However, the traits are covered by semver guarantees, so feel free to use them in your own code.
+
+/// Metadata about an RPC interface for runtime introspection.
+#[derive(Debug, Clone)]
+pub struct InterfaceDefinition<TypeInfo> {
+	/// The name of the interface.
+	pub name: String,
+
+	/// The documentation of the interface.
+	///
+	/// This string may contain rustdoc compatible markup.
+	pub doc: String,
+
+	/// The list of services in the interface.
+	pub services: Vec<ServiceDefinition<TypeInfo>>,
+
+	/// The list of streams in the interface.
+	pub streams: Vec<StreamDefinition<TypeInfo>>,
+}
+
+/// Metadata about a service for runtime intropection.
+#[derive(Debug, Clone)]
+pub struct ServiceDefinition<TypeInfo> {
+	/// The name of the service.
+	pub name: String,
+
+	/// The documentation of the service.
+	///
+	/// This string may contain rustdoc compatible markup.
+	pub doc: String,
+
+	/// The service ID of the service.
+	pub service_id: i32,
+
+	/// Information about the request body.
+	pub request_body: TypeInfo,
+
+	/// Information about the response body.
+	pub response_body: TypeInfo,
+
+	/// Information about the request updates.
+	pub request_updates: Vec<UpdateDefinition<TypeInfo>>,
+
+	/// Information about the response updates.
+	pub response_updates: Vec<UpdateDefinition<TypeInfo>>,
+}
+
+/// Metadata about a service update for runtime intropection.
+#[derive(Debug, Clone)]
+pub struct UpdateDefinition<TypeInfo> {
+	/// The name of the update message.
+	pub name: String,
+
+	/// The documentation of the update message.
+	///
+	/// This string may contain rustdoc compatible markup.
+	pub doc: String,
+
+	/// The service ID of the update message.
+	pub service_id: i32,
+
+	/// Information about the message body.
+	pub body: TypeInfo,
+}
+
+/// Metadata about a stream message for runtime intropection.
+#[derive(Debug, Clone)]
+pub struct StreamDefinition<TypeInfo> {
+	/// The name of the stream message.
+	pub name: String,
+
+	/// The documentation of the stream message.
+	///
+	/// This string may contain rustdoc compatible markup.
+	pub doc: String,
+
+	/// The service ID of the stream message.
+	pub service_id: i32,
+
+	/// Information about the message body.
+	pub body: TypeInfo,
+}
+
+/// Trait for formats that can provide runtime type information.
+pub trait IntrospectableFormat: crate::util::format::Format {
+	/// The return type for the [`Self::type_info()`] function.
+	type TypeInfo;
+}
+
+/// Trait for formats to provide runtime type information about a message body.
+pub trait FormatTypeInfo<T: ?Sized>: IntrospectableFormat {
+	/// Get type information about a type.
+	fn type_info() -> Self::TypeInfo;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ mod peer_handle;
 mod request;
 mod request_tracker;
 
+pub mod introspection;
 pub mod transport;
 pub mod util;
 

--- a/src/util/format.rs
+++ b/src/util/format.rs
@@ -21,7 +21,7 @@ pub trait Format {
 }
 
 /// Trait for formats that can encode `T` to a message body.
-pub trait EncodeBody<T>: Format {
+pub trait EncodeBody<T: ?Sized>: Format {
 	/// Encode the value to a message body.
 	fn encode_body(value: &T) -> Result<Self::Body, Box<dyn std::error::Error + Send>>;
 }


### PR DESCRIPTION
This PR adds introspection for generated interfaces.

It uses the serialization format (`F`) to get type information for message bodies. This allows different formats to serialize the same type differently. It also decouples this from the work in fizyr-binary, which is important, because `fizyr-binary` is not (currently) open source.

And even if it was, it's not nice to tie this to a single serialization format.

As usual, it may be best to read the different commits one. I tried to keep them neatly organized.