### PR TITLE
Rename crate::util::format module to crate::format.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - [add][minor] Add runtime interface introspection.
 - [fix][minor] Remove the `Sized` restriction for the `EncodeBody` trait.
 - [impl][patch] Use `poll_write_vectored` in the TCP transport to write the header and body with a single syscall.
+- [rename][major] Rename `crate::util::format` module to `crate::format`.
 
 # Version 0.5.0-alpha7 - 2022-01-10
 - [add][minor] Add a specific `Format` trait for generated interaces to avoid writing overly long trait bounds.

--- a/macros-tests/src/lib.rs
+++ b/macros-tests/src/lib.rs
@@ -2,18 +2,18 @@ pub mod camera;
 
 pub struct Json;
 
-impl fizyr_rpc::util::format::Format for Json {
+impl fizyr_rpc::format::Format for Json {
 	type Body = fizyr_rpc::StreamBody;
 }
 
-impl<T: serde::de::DeserializeOwned> fizyr_rpc::util::format::DecodeBody<T> for Json {
+impl<T: serde::de::DeserializeOwned> fizyr_rpc::format::DecodeBody<T> for Json {
 	fn decode_body(body: Self::Body) -> Result<T, Box<dyn std::error::Error + Send>> {
 		serde_json::from_slice(&body.data)
 			.map_err(|e| Box::new(e) as _)
 	}
 }
 
-impl<T: serde::Serialize + ?Sized> fizyr_rpc::util::format::EncodeBody<T> for Json {
+impl<T: serde::Serialize + ?Sized> fizyr_rpc::format::EncodeBody<T> for Json {
 	fn encode_body(value: &T) -> Result<fizyr_rpc::StreamBody, Box<dyn std::error::Error + Send>> {
 		serde_json::to_vec(value)
 			.map(fizyr_rpc::StreamBody::from)

--- a/macros-tests/tests/camera.rs
+++ b/macros-tests/tests/camera.rs
@@ -1,10 +1,10 @@
 use assert2::{let_assert, assert};
 use fizyr_rpc::{UnixStreamPeer, UnixStreamTransport};
-use fizyr_rpc::util::format::Format;
+use fizyr_rpc::format::Format;
 
 use macros_tests::{camera, Json};
 
-fn client_server_pair<F: fizyr_rpc::util::format::Format<Body = fizyr_rpc::StreamBody>>() -> std::io::Result<(camera::Client<F>, camera::Server<F>)> {
+fn client_server_pair<F: fizyr_rpc::format::Format<Body = fizyr_rpc::StreamBody>>() -> std::io::Result<(camera::Client<F>, camera::Server<F>)> {
 	let (client, server) = tokio::net::UnixStream::pair()?;
 	let client = UnixStreamPeer::spawn(UnixStreamTransport::new(client, Default::default()));
 	let server = UnixStreamPeer::spawn(UnixStreamTransport::new(server, Default::default()));
@@ -84,7 +84,7 @@ async fn record() {
 async fn record_state() {
 	use camera::camera_events;
 
-	fn client_server_pair<F: fizyr_rpc::util::format::Format<Body = fizyr_rpc::StreamBody>>() -> std::io::Result<(camera_events::Client<F>, camera_events::Server<F>)> {
+	fn client_server_pair<F: fizyr_rpc::format::Format<Body = fizyr_rpc::StreamBody>>() -> std::io::Result<(camera_events::Client<F>, camera_events::Server<F>)> {
 		let (client, server) = tokio::net::UnixStream::pair()?;
 		let client = UnixStreamPeer::spawn(UnixStreamTransport::new(client, Default::default()));
 		let server = UnixStreamPeer::spawn(UnixStreamTransport::new(server, Default::default()));

--- a/macros/src/interface/generate/client.rs
+++ b/macros/src/interface/generate/client.rs
@@ -11,11 +11,11 @@ pub fn generate_client(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 	let visibility = interface.visibility();
 	item_tokens.extend(quote! {
 		#[doc = #client_doc]
-		#visibility struct Client<F: #fizyr_rpc::util::format::Format> {
+		#visibility struct Client<F: #fizyr_rpc::format::Format> {
 			peer: #fizyr_rpc::PeerWriteHandle<F::Body>,
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for Client<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for Client<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("peer", &self.peer)
@@ -23,7 +23,7 @@ pub fn generate_client(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::clone::Clone for Client<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::clone::Clone for Client<F> {
 			fn clone(&self) -> Self {
 				Self {
 					peer: self.peer.clone(),
@@ -31,20 +31,20 @@ pub fn generate_client(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::convert::From<#fizyr_rpc::PeerWriteHandle<F::Body>> for Client<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::convert::From<#fizyr_rpc::PeerWriteHandle<F::Body>> for Client<F> {
 			fn from(other: #fizyr_rpc::PeerWriteHandle<F::Body>) -> Self {
 				Self::new(other)
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::convert::From<#fizyr_rpc::PeerHandle<F::Body>> for Client<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::convert::From<#fizyr_rpc::PeerHandle<F::Body>> for Client<F> {
 			fn from(other: #fizyr_rpc::PeerHandle<F::Body>) -> Self {
 				let (_read, write) = other.split();
 				Self::new(write)
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> Client<F> {
+		impl<F: #fizyr_rpc::format::Format> Client<F> {
 			/// Create a new interface-specific RPC client from a raw write handle.
 			pub fn new(peer: #fizyr_rpc::PeerWriteHandle<F::Body>) -> Self {
 				Self { peer }

--- a/macros/src/interface/generate/format_trait.rs
+++ b/macros/src/interface/generate/format_trait.rs
@@ -22,10 +22,10 @@ pub fn generate_format_trait(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		types.push(stream.body_type())
 	}
 
-	let mut bounds = quote!(#fizyr_rpc::util::format::Format);
+	let mut bounds = quote!(#fizyr_rpc::format::Format);
 	for typ in &types {
-		bounds.extend(quote!( + #fizyr_rpc::util::format::EncodeBody<#typ>));
-		bounds.extend(quote!( + #fizyr_rpc::util::format::DecodeBody<#typ>));
+		bounds.extend(quote!( + #fizyr_rpc::format::EncodeBody<#typ>));
+		bounds.extend(quote!( + #fizyr_rpc::format::DecodeBody<#typ>));
 	}
 
 	let visibility = interface.visibility();

--- a/macros/src/interface/generate/message_enum.rs
+++ b/macros/src/interface/generate/message_enum.rs
@@ -31,7 +31,7 @@ pub fn generate_message_enum(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		});
 
 		decode_all.extend(quote! {
-			F: #fizyr_rpc::util::format::DecodeBody<#body_type>,
+			F: #fizyr_rpc::format::DecodeBody<#body_type>,
 		});
 
 		to_message.extend(quote! {
@@ -43,7 +43,7 @@ pub fn generate_message_enum(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		});
 
 		encode_all.extend(quote! {
-			F: #fizyr_rpc::util::format::EncodeBody<#body_type>,
+			F: #fizyr_rpc::format::EncodeBody<#body_type>,
 		});
 
 		let is_fn_name = syn::Ident::new(&format!("is_{}", message.name()), Span::call_site());
@@ -104,7 +104,7 @@ pub fn generate_message_enum(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 			#impl_tokens
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> #fizyr_rpc::util::format::FromMessage<F> for #enum_name
+		impl<F: #fizyr_rpc::format::Format> #fizyr_rpc::format::FromMessage<F> for #enum_name
 		where
 			#decode_all
 		{
@@ -116,7 +116,7 @@ pub fn generate_message_enum(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> #fizyr_rpc::util::format::ToMessage<F> for #enum_name
+		impl<F: #fizyr_rpc::format::Format> #fizyr_rpc::format::ToMessage<F> for #enum_name
 		where
 			#encode_all
 		{

--- a/macros/src/interface/generate/server.rs
+++ b/macros/src/interface/generate/server.rs
@@ -30,7 +30,7 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 		let variant_name = syn::Ident::new(&to_upper_camel_case(&stream_name.to_string()), Span::call_site());
 		let body_type = stream.body_type();
 		recv_message_where.extend(quote! {
-			F: #fizyr_rpc::util::format::DecodeBody<#body_type>,
+			F: #fizyr_rpc::format::DecodeBody<#body_type>,
 		});
 		decode_stream_arms.extend(quote! {
 			#service_id =>  {
@@ -48,7 +48,7 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 
 	if !interface.streams().is_empty() {
 		recv_message_where.extend(quote! {
-			StreamMessage: #fizyr_rpc::util::format::FromMessage<F>,
+			StreamMessage: #fizyr_rpc::format::FromMessage<F>,
 		});
 		received_msg_variants.extend(quote! {
 			/// A stream message.
@@ -69,7 +69,7 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 		let variant_name = syn::Ident::new(&to_upper_camel_case(&service_name.to_string()), Span::call_site());
 		let request_type = service.request_type();
 		recv_message_where.extend(quote! {
-			F: #fizyr_rpc::util::format::DecodeBody<#request_type>,
+			F: #fizyr_rpc::format::DecodeBody<#request_type>,
 		});
 		decode_request_arms.extend(quote! {
 			#service_id =>  {
@@ -89,7 +89,7 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 	if !interface.services().is_empty() {
 		received_msg_generics.extend(quote!(F));
 		received_msg_where.extend(quote! {
-			F: #fizyr_rpc::util::format::Format,
+			F: #fizyr_rpc::format::Format,
 		});
 		received_msg_variants.extend(quote! {
 			/// A request message.
@@ -108,11 +108,11 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 	let server_doc = format!("RPC server for the {} interface.", interface.name());
 	item_tokens.extend(quote! {
 		#[doc = #server_doc]
-		#visibility struct Server<F: #fizyr_rpc::util::format::Format> {
+		#visibility struct Server<F: #fizyr_rpc::format::Format> {
 			peer: #fizyr_rpc::PeerReadHandle<F::Body>,
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for Server<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for Server<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("peer", &self.peer)
@@ -120,7 +120,7 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> Server<F> {
+		impl<F: #fizyr_rpc::format::Format> Server<F> {
 			/// Create a new interface-specific RPC server from a raw write handle.
 			fn new(peer: #fizyr_rpc::PeerReadHandle<F::Body>) -> Self {
 				Self { peer }
@@ -161,13 +161,13 @@ pub fn generate_server(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, in
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::convert::From<#fizyr_rpc::PeerReadHandle<F::Body>> for Server<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::convert::From<#fizyr_rpc::PeerReadHandle<F::Body>> for Server<F> {
 			fn from(other: #fizyr_rpc::PeerReadHandle<F::Body>) -> Self {
 				Self::new(other)
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::convert::From<#fizyr_rpc::PeerHandle<F::Body>> for Server<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::convert::From<#fizyr_rpc::PeerHandle<F::Body>> for Server<F> {
 			fn from(other: #fizyr_rpc::PeerHandle<F::Body>) -> Self {
 				let (read, _write) = other.split();
 				Self::new(read)
@@ -222,11 +222,11 @@ fn generate_received_request_enum(item_tokens: &mut TokenStream, fizyr_rpc: &syn
 	let visibility = interface.visibility();
 	item_tokens.extend(quote! {
 		#[doc = #enum_doc]
-		#visibility enum ReceivedRequestHandle<F: #fizyr_rpc::util::format::Format> {
+		#visibility enum ReceivedRequestHandle<F: #fizyr_rpc::format::Format> {
 			#variant_tokens
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for ReceivedRequestHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for ReceivedRequestHandle<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				match self {
 					#debug_tokens

--- a/macros/src/interface/generate/services.rs
+++ b/macros/src/interface/generate/services.rs
@@ -45,8 +45,8 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 			#[allow(clippy::ptr_arg)]
 			pub async fn #service_name(&self, #request_param) -> ::core::result::Result<#response_type, #fizyr_rpc::Error>
 			where
-				F: #fizyr_rpc::util::format::EncodeBody<#request_type>,
-				F: #fizyr_rpc::util::format::DecodeBody<#response_type>,
+				F: #fizyr_rpc::format::EncodeBody<#request_type>,
+				F: #fizyr_rpc::format::DecodeBody<#response_type>,
 			{
 				let request_body = #request_body.map_err(#fizyr_rpc::Error::encode_failed)?;
 				let mut request = self.peer.send_request(#service_id, request_body).await?;
@@ -71,8 +71,8 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 			#[allow(clippy::ptr_arg)]
 			pub async fn #service_name(&self, #request_param) -> ::core::result::Result<#service_name::SentRequestHandle<F>, #fizyr_rpc::Error>
 			where
-				F: #fizyr_rpc::util::format::EncodeBody<#request_type>,
-				F: #fizyr_rpc::util::format::DecodeBody<#response_type>,
+				F: #fizyr_rpc::format::EncodeBody<#request_type>,
+				F: #fizyr_rpc::format::DecodeBody<#response_type>,
 			{
 				let request_body = #request_body.map_err(#fizyr_rpc::Error::encode_failed)?;
 				let mut request = self.peer.send_request(#service_id, request_body).await?;
@@ -125,7 +125,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 		#doc_recv_update
 		pub async fn recv_response(&mut self) -> ::core::result::Result<#response_type, #fizyr_rpc::Error>
 		where
-			F: #fizyr_rpc::util::format::DecodeBody<#response_type>,
+			F: #fizyr_rpc::format::DecodeBody<#response_type>,
 		{
 			let response = self.request.recv_response().await?;
 			if response.header.service_id == #fizyr_rpc::service_id::ERROR {
@@ -168,16 +168,16 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 
 	item_tokens.extend(quote! {
 		#[doc = #handle_doc]
-		pub struct SentRequestHandle<F: #fizyr_rpc::util::format::Format> {
+		pub struct SentRequestHandle<F: #fizyr_rpc::format::Format> {
 			pub(super) request: #fizyr_rpc::SentRequestHandle<F::Body>,
 		}
 
 		#[doc = #write_handle_doc]
-		pub struct SentRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
+		pub struct SentRequestWriteHandle<F: #fizyr_rpc::format::Format> {
 			pub(super) request: #fizyr_rpc::SentRequestWriteHandle<F::Body>,
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for SentRequestHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for SentRequestHandle<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
@@ -187,7 +187,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for SentRequestWriteHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for SentRequestWriteHandle<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
@@ -197,7 +197,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::clone::Clone for SentRequestWriteHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::clone::Clone for SentRequestWriteHandle<F> {
 			fn clone(&self) -> Self {
 				Self {
 					request: self.request.clone(),
@@ -205,7 +205,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> SentRequestHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> SentRequestHandle<F> {
 			/// Get the raw request.
 			pub fn inner(&self) -> &#fizyr_rpc::SentRequestHandle<F::Body> {
 				&self.request
@@ -246,7 +246,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 			#write_handle_impl_tokens
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> SentRequestWriteHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> SentRequestWriteHandle<F> {
 			/// Get the raw request.
 			pub fn inner(&self) -> &#fizyr_rpc::SentRequestWriteHandle<F::Body> {
 				&self.request
@@ -296,7 +296,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		#[allow(clippy::ptr_arg)]
 		pub async fn send_response(&self, response: &#response_type) -> ::core::result::Result<(), #fizyr_rpc::Error>
 		where
-			F: #fizyr_rpc::util::format::EncodeBody<#response_type>,
+			F: #fizyr_rpc::format::EncodeBody<#response_type>,
 		{
 			let encoded = F::encode_body(response).map_err(#fizyr_rpc::Error::encode_failed)?;
 			let response = self.request.send_response(#service_id, encoded).await?;
@@ -313,16 +313,16 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 	let write_handle_doc = format!("Write-only handle for a received `{}` request.", service.name());
 	item_tokens.extend(quote! {
 		#[doc = #handle_doc]
-		pub struct ReceivedRequestHandle<F: #fizyr_rpc::util::format::Format> {
+		pub struct ReceivedRequestHandle<F: #fizyr_rpc::format::Format> {
 			pub(super) request: #fizyr_rpc::ReceivedRequestHandle<F::Body>,
 		}
 
 		#[doc = #write_handle_doc]
-		pub struct ReceivedRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
+		pub struct ReceivedRequestWriteHandle<F: #fizyr_rpc::format::Format> {
 			pub(super) request: #fizyr_rpc::ReceivedRequestWriteHandle<F::Body>,
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for ReceivedRequestHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for ReceivedRequestHandle<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
@@ -332,7 +332,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for ReceivedRequestWriteHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::fmt::Debug for ReceivedRequestWriteHandle<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
@@ -342,7 +342,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ::core::clone::Clone for ReceivedRequestWriteHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ::core::clone::Clone for ReceivedRequestWriteHandle<F> {
 			fn clone(&self) -> Self {
 				Self {
 					request: self.request.clone(),
@@ -350,7 +350,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ReceivedRequestHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ReceivedRequestHandle<F> {
 			/// Get the raw request.
 			///
 			/// Note that the request body has been consumed when it was parsed.
@@ -400,7 +400,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 			#write_handle_impl_tokens
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> ReceivedRequestWriteHandle<F> {
+		impl<F: #fizyr_rpc::format::Format> ReceivedRequestWriteHandle<F> {
 			/// Get the raw request.
 			///
 			/// Note that the request body has been consumed when it was parsed.
@@ -446,7 +446,7 @@ fn generate_send_update_functions(impl_tokens: &mut TokenStream, fizyr_rpc: &syn
 		#[allow(clippy::ptr_arg)]
 		pub async fn send_update(&self, update: &#enum_type) -> ::core::result::Result<(), #fizyr_rpc::Error>
 		where
-			#enum_type: #fizyr_rpc::util::format::ToMessage<F>,
+			#enum_type: #fizyr_rpc::format::ToMessage<F>,
 		{
 			let (service_id, body) = F::encode_message(update).map_err(#fizyr_rpc::Error::encode_failed)?;
 			self.request.send_update(service_id, body).await?;
@@ -473,7 +473,7 @@ fn generate_send_update_functions(impl_tokens: &mut TokenStream, fizyr_rpc: &syn
 			#[allow(clippy::ptr_arg)]
 			pub async fn #function_name(&self, #body_arg) -> ::core::result::Result<(), #fizyr_rpc::Error>
 			where
-				F: #fizyr_rpc::util::format::EncodeBody<#body_type>,
+				F: #fizyr_rpc::format::EncodeBody<#body_type>,
 			{
 				let body = F::encode_body(#body_val).map_err(#fizyr_rpc::Error::encode_failed)?;
 				self.request.send_update(#service_id, body).await?;
@@ -511,7 +511,7 @@ fn generate_recv_update_function(impl_tokens: &mut TokenStream, fizyr_rpc: &syn:
 		let body_type = update.body_type();
 		let variant_name = syn::Ident::new(&to_upper_camel_case(&update.name().to_string()), Span::call_site());
 		where_clause.extend(quote! {
-			F: #fizyr_rpc::util::format::DecodeBody<#body_type>,
+			F: #fizyr_rpc::format::DecodeBody<#body_type>,
 		});
 		decode_arms.extend(quote! {
 			#service_id =>  {

--- a/macros/src/interface/generate/streams.rs
+++ b/macros/src/interface/generate/streams.rs
@@ -35,7 +35,7 @@ pub fn generate_streams(item_tokens: &mut TokenStream, client_impl_tokens: &mut 
 			#[allow(clippy::ptr_arg)]
 			pub async fn #fn_name(&self, #body_arg) -> ::core::result::Result<(), #fizyr_rpc::Error>
 			where
-				F: #fizyr_rpc::util::format::EncodeBody<#body_type>,
+				F: #fizyr_rpc::format::EncodeBody<#body_type>,
 			{
 				let encoded = F::encode_body(#body_val).map_err(#fizyr_rpc::Error::encode_failed)?;
 				self.peer.send_stream(#service_id, encoded).await?;

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,8 @@
 //! Traits for converting between RPC messages and Rust values.
+//!
+//! These traits are used by generated interfaces from the [`interface!`] macro.
+//! Normally, you would only implement these traits for your own serialization format.
+//! However, the traits are covered by semver guarantees, so feel free to use them in your own code.
 
 use crate::Error;
 

--- a/src/introspection.rs
+++ b/src/introspection.rs
@@ -86,7 +86,7 @@ pub struct StreamDefinition<TypeInfo> {
 }
 
 /// Trait for formats that can provide runtime type information.
-pub trait IntrospectableFormat: crate::util::format::Format {
+pub trait IntrospectableFormat: crate::format::Format {
 	/// The return type for the [`Self::type_info()`] function.
 	type TypeInfo;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ mod request;
 mod request_tracker;
 
 pub mod introspection;
+pub mod format;
 pub mod transport;
 pub mod util;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,7 +10,6 @@ mod accept;
 mod connect;
 mod into_transport;
 mod select;
-pub mod format;
 
 pub use accept::{Accept, Bind, Listener};
 pub use connect::Connect;


### PR DESCRIPTION
This PR moves the `crate::util::format` module to just `crate::format`. I think it's too tucked away right now, for no good reason.

I'm tempted to also merge the `crate::introspection` module into `crate::format`, since it's all related to the concept of a serialization format anyway.

@dan-jfisher, @hgaiser: What do you think?