### PR TITLE
Add RecvMessageError::is_connection_aborted and request_handle[_mut].

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [add][minor] Add utility functions for working with `RecvMessageError`.
+
 # Version 0.5.0-alpha9 - 2022-04-26
 - [fix][minor] Fix unintended infinite recursion in generic trait implementations.
 - [fix][patch] Fix `needless_question_mark` clippy warnings in generated code.

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,49 @@ impl Error {
 	}
 }
 
+impl<Body> RecvMessageError<Body> {
+	/// Check if this error is caused by the remote peer closing the connection cleanly.
+	pub fn is_connection_aborted(&self) -> bool {
+		if let Self::Other(e) = self {
+			e.is_connection_aborted()
+		} else {
+			false
+		}
+	}
+
+	/// Get the raw request handle associated with the received message.
+	///
+	/// The request handle can be used to send an error response to unknown or invalid requests.
+	///
+	/// For errors other than [`Self::UnknownRequest`] and [`Self::InvalidRequest`],
+	/// this function returns [`None`].
+	pub fn request_handle(&self) -> Option<&crate::ReceivedRequestHandle<Body>> {
+		match self {
+			Self::Other(_error) => None,
+			Self::UnknownStream(_message) => None,
+			Self::UnknownRequest(request, _body) => Some(request),
+			Self::InvalidStream(_message, _error) => None,
+			Self::InvalidRequest(request, _error) => Some(request),
+		}
+	}
+
+	/// Get the a mutable reference to the raw request handle associated with the received message.
+	///
+	/// The request handle can be used to send an error response to unknown or invalid requests.
+	///
+	/// For errors other than [`Self::UnknownRequest`] and [`Self::InvalidRequest`],
+	/// this function returns [`None`].
+	pub fn request_handle_mut(&mut self) -> Option<&mut crate::ReceivedRequestHandle<Body>> {
+		match self {
+			Self::Other(_error) => None,
+			Self::UnknownStream(_message) => None,
+			Self::UnknownRequest(request, _body) => Some(request),
+			Self::InvalidStream(_message, _error) => None,
+			Self::InvalidRequest(request, _error) => Some(request),
+		}
+	}
+}
+
 impl From<std::io::Error> for Error {
 	fn from(other: std::io::Error) -> Self {
 		Self::io_error(other)


### PR DESCRIPTION
This PR adds some utility functions to `RecvMessageError` to make working with it easier.

With this PR, we can rewrite this:
```rust
loop {
  let message = match peer.recv_message().await {
    Ok(message) => message,
    Err(error) => {
      match error {
        RecvMessageError::Other(error) => {
          return if error.is_connection_aborted() {
            log::info!("Connection closed by peer");
            Ok(())
          } else {
            Err(format!("Failed to receive message from peer: {}", error))
          }
        },
        RecvMessageError::UnknownRequest(request, _body) => {
          log::warn!("Received unknown request with service ID {}", request.service_id());
          request
            .send_error_response(&format!("unknown service ID: {}", request.service_id()))
            .await
            .map_err(|e| format!("Failed to send error response: {}", e))?
        },
        RecvMessageError::InvalidRequest(request, error) => {
          let error = error.to_string();
          log::warn!(
            "Invalid request body for service ID {}: {}",
            request.service_id(),
            error
          );
          request
            .send_error_response(&error)
            .await
            .map_err(|e| format!("Failed to send error response: {}", e))?
        },
        stream_error => {
          log::warn!("{}", stream_error)
        },
      };
      continue;
    },
  };

  // Do stuff with message.
}
```


As this:
```rust
loop {
  let message = match peer.recv_message().await {
    Ok(message) => message,
    Err(error) => {
      if error.is_connection_aborted() {
        log::info!("Connection closed by peer");
        return Ok(());
      }

      log::warn!("Error while receiving message: {}", error);
      if let Some(request) = error.request_handle() {
        request
          .send_error_response(error.to_string())
          .await
          .map_err(|e| format!("Failed to send error response: {}", e))?;
      }
      continue;
    },
  };

  // Do stuff with message.
}

```