### PR TITLE
Provide transport info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - [add][minor] Add utility functions for working with `RecvMessageError`.
 - [add][minor] Add `Transport::info()` function to get information about a transport.
 - [add][minor] Allow direct access to the underlying `Transport` of a `Peer`.
+- [add][minor] Allow direct access to the underlying stream or socket of a `Transport`.
 
 # Version 0.5.0-alpha9 - 2022-04-26
 - [fix][minor] Fix unintended infinite recursion in generic trait implementations.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- [add][major] Provide transport info when spawning peers without giving access to the transport.
 - [add][minor] Add utility functions for working with `RecvMessageError`.
 - [add][minor] Add `Transport::info()` function to get information about a transport.
 - [add][minor] Allow direct access to the underlying `Transport` of a `Peer`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # Unreleased
 - [add][minor] Add utility functions for working with `RecvMessageError`.
+- [add][minor] Add `Transport::info()` function to get information about a transport.
 
 # Version 0.5.0-alpha9 - 2022-04-26
 - [fix][minor] Fix unintended infinite recursion in generic trait implementations.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Unreleased
 - [add][minor] Add utility functions for working with `RecvMessageError`.
 - [add][minor] Add `Transport::info()` function to get information about a transport.
+- [add][minor] Allow direct access to the underlying `Transport` of a `Peer`.
 
 # Version 0.5.0-alpha9 - 2022-04-26
 - [fix][minor] Fix unintended infinite recursion in generic trait implementations.

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -17,8 +17,9 @@ async fn main() {
 
 async fn do_main(options: &Options) -> Result<(), String> {
 	// Connect to a remote server.
-	let peer = TcpPeer::connect(&options.address, Default::default()).await
+	let (peer, info) = TcpPeer::connect(&options.address, Default::default()).await
 		.map_err(|e| format!("failed to connect to {}: {}", options.address, e))?;
+	eprintln!("Connected to: {}", info.remote_address());
 
 	// Send a request to the remote peer.
 	let mut request = peer

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -20,11 +20,12 @@ async fn do_main(options: &Options) -> Result<(), String> {
 	let mut server = TcpListener::bind(options.bind.as_str(), Default::default())
 		.await
 		.map_err(|e| format!("failed to bind to {}: {}", options.bind, e))?;
-	eprintln!("listening on {}", options.bind);
+	eprintln!("Listening on {}", options.bind);
 
 	// Run the accept loop.
 	// The lambda returns a future that will be spawned in a new task for each peer.
-	let result = server.run(|peer| async {
+	let result = server.run(|peer, info| async move {
+		eprintln!("Accepted connection from: {}", info.remote_address());
 		if let Err(e) = handle_peer(peer).await {
 			eprintln!("Error: {}", e);
 		}

--- a/examples/unix-seqpacket-client.rs
+++ b/examples/unix-seqpacket-client.rs
@@ -18,8 +18,13 @@ async fn main() {
 
 async fn do_main(options: &Options) -> Result<(), String> {
 	// Connect to a remote server.
-	let peer = UnixSeqpacketPeer::connect(&options.socket, Default::default()).await
+	let (peer, info) = UnixSeqpacketPeer::connect(&options.socket, Default::default()).await
 		.map_err(|e| format!("failed to connect to {}: {}", options.socket.display(), e))?;
+	if let Some(pid) = info.process_id() {
+		eprintln!("Connected to process {} of user {}", pid, info.user_id());
+	} else {
+		eprintln!("Connected to process of user {}", info.user_id());
+	}
 
 	// Send a request to the remote peer.
 	let mut request = peer

--- a/examples/unix-seqpacket-server.rs
+++ b/examples/unix-seqpacket-server.rs
@@ -24,7 +24,12 @@ async fn do_main(options: &Options) -> Result<(), String> {
 
 	// Run the accept loop.
 	// The lambda returns a future that will be spawned in a new task for each peer.
-	let result = server.run(|peer| async {
+	let result = server.run(|peer, info| async move {
+		if let Some(pid) = info.process_id() {
+			eprintln!("Accepted connection from process {} of user {}", pid, info.user_id());
+		} else {
+			eprintln!("Accepted connection from process of user {}", info.user_id());
+		}
 		if let Err(e) = handle_peer(peer).await {
 			eprintln!("Error: {}", e);
 		}

--- a/examples/unix-stream-client.rs
+++ b/examples/unix-stream-client.rs
@@ -18,8 +18,13 @@ async fn main() {
 
 async fn do_main(options: &Options) -> Result<(), String> {
 	// Connect to a remote server.
-	let peer = UnixStreamPeer::connect(&options.socket, Default::default()).await
+	let (peer, info) = UnixStreamPeer::connect(&options.socket, Default::default()).await
 		.map_err(|e| format!("failed to connect to {}: {}", options.socket.display(), e))?;
+	if let Some(pid) = info.process_id() {
+		eprintln!("Connected to process {} of user {}", pid, info.user_id());
+	} else {
+		eprintln!("Connected to process of user {}", info.user_id());
+	}
 
 	// Send a request to the remote peer.
 	let mut request = peer

--- a/examples/unix-stream-server.rs
+++ b/examples/unix-stream-server.rs
@@ -24,7 +24,12 @@ async fn do_main(options: &Options) -> Result<(), String> {
 
 	// Run the accept loop.
 	// The lambda returns a future that will be spawned in a new task for each peer.
-	let result = server.run(|peer| async {
+	let result = server.run(|peer, info| async move {
+		if let Some(pid) = info.process_id() {
+			eprintln!("Accepted connection from process {} of user {}", pid, info.user_id());
+		} else {
+			eprintln!("Accepted connection from process of user {}", info.user_id());
+		}
 		if let Err(e) = handle_peer(peer).await {
 			eprintln!("Error: {}", e);
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,8 @@
 //! use fizyr_rpc::{TcpPeer, StreamConfig};
 //!
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut peer = TcpPeer::connect("localhost:1337", StreamConfig::default()).await?;
+//! let (peer, info) = TcpPeer::connect("localhost:1337", StreamConfig::default()).await?;
+//! eprintln!("Connected to: {}", info.remote_address());
 //! let mut request = peer.send_request(1, &b"Hello World!"[..]).await?;
 //!
 //! while let Some(update) = request.recv_update().await {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -64,7 +64,7 @@ impl<Transport: crate::transport::Transport> Peer<Transport> {
 	/// The returned [`PeerHandle`] is used to send and receive requests and stream messages.
 	///
 	/// If [`Self::run()`] is not called (or aborted),
-	/// then none of the functions of the [`PeerHandle`] will work.
+	/// none of the functions of the [`PeerHandle`] will work.
 	/// They will just wait forever.
 	///
 	/// You can also use [`Self::spawn()`] to run the read/write loop in a newly spawned task,
@@ -113,13 +113,14 @@ impl<Transport: crate::transport::Transport> Peer<Transport> {
 	/// The type of address accepted depends on the transport.
 	/// For internet transports such as TCP, the address must implement [`tokio::net::ToSocketAddrs`].
 	/// For unix transports, the address must implement [`AsRef<std::path::Path>`].
-	pub async fn connect<'a, Address>(address: Address, config: Transport::Config) -> std::io::Result<PeerHandle<Transport::Body>>
+	pub async fn connect<'a, Address>(address: Address, config: Transport::Config) -> std::io::Result<(PeerHandle<Transport::Body>, Transport::Info)>
 	where
 		Address: 'a,
 		Transport: util::Connect<'a, Address>,
 	{
 		let transport = Transport::connect(address, config).await?;
-		Ok(Self::spawn(transport))
+		let info = transport.info()?;
+		Ok((Self::spawn(transport), info))
 	}
 
 	/// Run the read/write loop.

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -172,6 +172,16 @@ impl<Transport: crate::transport::Transport> Peer<Transport> {
 			},
 		}
 	}
+
+	/// Get direct access to the underlying transport.
+	pub fn transport(&self) -> &Transport {
+		&self.transport
+	}
+
+	/// Get direct mutable access to the underlying transport.
+	pub fn transport_mut(&mut self) -> &mut Transport {
+		&mut self.transport
+	}
 }
 
 /// Implementation of the read loop of a peer.

--- a/src/transport/stream/transport.rs
+++ b/src/transport/stream/transport.rs
@@ -24,9 +24,9 @@ pub struct StreamTransport<Stream> {
 
 /// The read half of a [`StreamTransport`].
 #[allow(dead_code)] // Not used when transports are disabled.
-pub struct StreamReadHalf<R> {
+pub struct StreamReadHalf<ReadStream> {
 	/// The read half of the underlying stream.
-	pub(super) stream: R,
+	pub(super) stream: ReadStream,
 
 	/// The maximum body length to accept when reading messages.
 	pub(super) max_body_len: u32,
@@ -46,9 +46,9 @@ pub struct StreamReadHalf<R> {
 
 /// The write half of a [`StreamTransport`].
 #[allow(dead_code)] // Not used when transports are disabled.
-pub struct StreamWriteHalf<W> {
+pub struct StreamWriteHalf<WriteStream> {
 	/// The write half of the underlying stream.
-	pub(super) stream: W,
+	pub(super) stream: WriteStream,
 
 	/// The maximum body length to enforce for messages.
 	pub(super) max_body_len: u32,
@@ -73,11 +73,26 @@ where
 	pub fn new_default(stream: Stream) -> Self {
 		Self::new(stream, StreamConfig::default())
 	}
+
+	/// Get direct access to the underlying stream.
+	pub fn stream(&self) -> &Stream {
+		&self.stream
+	}
+
+	/// Get direct mutable access to the underlying stream.
+	pub fn stream_mut(&mut self) -> &Stream {
+		&mut self.stream
+	}
+
+	/// Consume the stream transport to retrieve the underlying stream.
+	pub fn into_stream(self) -> Stream {
+		self.stream
+	}
 }
 
-impl<R> StreamReadHalf<R> {
+impl<ReadStream> StreamReadHalf<ReadStream> {
 	#[allow(dead_code)] // Not used when transports are disabled.
-	pub(super) fn new(stream: R, max_body_len: u32) -> Self {
+	pub(super) fn new(stream: ReadStream, max_body_len: u32) -> Self {
 		Self {
 			stream,
 			max_body_len,
@@ -87,17 +102,41 @@ impl<R> StreamReadHalf<R> {
 			body_buffer: Vec::new(),
 		}
 	}
+
+	/// Get direct access to the underlying stream.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn stream(&self) -> &ReadStream {
+		&self.stream
+	}
+
+	/// Get direct mutable access to the underlying stream.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn stream_mut(&mut self) -> &ReadStream {
+		&mut self.stream
+	}
 }
 
-impl<W> StreamWriteHalf<W> {
+impl<WriteStream> StreamWriteHalf<WriteStream> {
 	#[allow(dead_code)] // Not used when transports are disabled.
-	pub(super) fn new(stream: W, max_body_len: u32) -> Self {
+	pub(super) fn new(stream: WriteStream, max_body_len: u32) -> Self {
 		Self {
 			stream,
 			max_body_len,
 			header_buffer: None,
 			bytes_written: 0,
 		}
+	}
+
+	/// Get direct access to the underlying stream.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn stream(&self) -> &WriteStream {
+		&self.stream
+	}
+
+	/// Get direct mutable access to the underlying stream.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn stream_mut(&mut self) -> &WriteStream {
+		&mut self.stream
 	}
 }
 

--- a/src/transport/unix/transport.rs
+++ b/src/transport/unix/transport.rs
@@ -12,9 +12,9 @@ pub struct UnixTransport<Socket> {
 
 /// The read half of a [`UnixTransport`].
 #[allow(dead_code)] // Not used when transports are disabled.
-pub struct UnixReadHalf<R> {
+pub struct UnixReadHalf<SocketReadHalf> {
 	/// The read half of the underlying socket.
-	pub(super) socket: R,
+	pub(super) socket: SocketReadHalf,
 
 	/// The maximum body length to accept when reading messages.
 	pub(super) max_body_len: u32,
@@ -28,9 +28,9 @@ pub struct UnixReadHalf<R> {
 
 /// The write half of a [`UnixTransport`].
 #[allow(dead_code)] // Not used when transports are disabled.
-pub struct UnixWriteHalf<W> {
+pub struct UnixWriteHalf<SocketWriteHalf> {
 	/// The write half of the underlying socket.
-	pub(super) socket: W,
+	pub(super) socket: SocketWriteHalf,
 
 	/// The maximum body length to enforce for messages.
 	pub(super) max_body_len: u32,
@@ -52,11 +52,26 @@ where
 	pub fn new_default(socket: Socket) -> Self {
 		Self::new(socket, UnixConfig::default())
 	}
+
+	/// Get direct access to the underlying socket.
+	pub fn socket(&self) -> &Socket {
+		&self.socket
+	}
+
+	/// Get direct mutable access to the underlying socket.
+	pub fn socket_mut(&mut self) -> &Socket {
+		&mut self.socket
+	}
+
+	/// Consume the socket transport to retrieve the underlying socket.
+	pub fn into_socket(self) -> Socket {
+		self.socket
+	}
 }
 
-impl<R> UnixReadHalf<R> {
+impl<SocketReadHalf> UnixReadHalf<SocketReadHalf> {
 	#[allow(dead_code)] // Not used when transports are disabled.
-	pub(super) fn new(socket: R, max_body_len: u32, max_fds: u32) -> Self {
+	pub(super) fn new(socket: SocketReadHalf, max_body_len: u32, max_fds: u32) -> Self {
 		Self {
 			socket,
 			max_body_len,
@@ -64,16 +79,40 @@ impl<R> UnixReadHalf<R> {
 			body_buffer: Vec::new(),
 		}
 	}
+
+	/// Get direct access to the underlying socket.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn socket(&self) -> &SocketReadHalf {
+		&self.socket
+	}
+
+	/// Get direct mutable access to the underlying socket.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn socket_mut(&mut self) -> &SocketReadHalf {
+		&mut self.socket
+	}
 }
 
-impl<W> UnixWriteHalf<W> {
+impl<SocketWriteHalf> UnixWriteHalf<SocketWriteHalf> {
 	#[allow(dead_code)] // Not used when transports are disabled.
-	pub(super) fn new(socket: W, max_body_len: u32, max_fds: u32) -> Self {
+	pub(super) fn new(socket: SocketWriteHalf, max_body_len: u32, max_fds: u32) -> Self {
 		Self {
 			socket,
 			max_body_len,
 			max_fds,
 		}
+	}
+
+	/// Get direct access to the underlying socket.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn socket(&self) -> &SocketWriteHalf {
+		&self.socket
+	}
+
+	/// Get direct mutable access to the underlying socket.
+	#[allow(dead_code)] // Not used when transports are disabled.
+	pub fn socket_mut(&mut self) -> &SocketWriteHalf {
+		&mut self.socket
 	}
 }
 


### PR DESCRIPTION
This PR makes information about the connection available to users of the crate.


It is not possible to retrieve this information through a `PeerHandle`, primarily because the `PeerHandle` has no idea which underlying transport is used. However, you can get the information from a `Transport` and from a `Peer` (through `peer.transport()`) before the `Peer` is spawned.

Additionally, functions that directly create a `PeerHandle` without exposing the `Transport` also provide you with the info object. This means `Peer::connect()`, `Listener::accept()` and `Listener::run()`.

For TCP connections, the information includes a local and remote socket address.

For connection oriented Unix sockets (stream and seqpacket), the information includes a UID, GID and PID. I did not add a local or remote address for these, since connected Unix sockets have no address.