### PR TITLE
Make Transports decide which errors are fatal.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- [add][major] Have `Transport` implementations decide which I/O errors are fatal.
 - [add][major] Provide transport info when spawning peers without giving access to the transport.
 - [add][minor] Add utility functions for working with `RecvMessageError`.
 - [add][minor] Add `Transport::info()` function to get information about a transport.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ categories = ["asynchronous", "network-programming"]
 edition = "2021"
 
 [features]
-tcp = ["tokio/net"]
-unix-stream = ["tokio/net"]
-unix-seqpacket = ["tokio-seqpacket"]
 macros = ["fizyr-rpc-macros"]
+tcp = ["tokio/net"]
+unix-seqpacket = ["tokio-seqpacket"]
+unix-stream = ["tokio/net"]
 
 [dependencies]
 byteorder = "1.3.4"
@@ -39,7 +39,7 @@ fizyr-rpc = { path = ".", features = ["unix-seqpacket", "unix-stream", "tcp"] }
 memfile = "0.2.0"
 
 [package.metadata.docs.rs]
-features = ["tcp", "unix-stream", "unix-seqpacket"]
+features = ["macros", "tcp", "unix-stream", "unix-seqpacket"]
 
 [workspace]
 members = ["macros", "macros-tests"]

--- a/macros/src/interface/generate/services.rs
+++ b/macros/src/interface/generate/services.rs
@@ -181,8 +181,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
 					.field("service_id", &self.service_id())
-					// TODO: use finish_non_exhaustive when it hits stable
-					.finish()
+					.finish_non_exhaustive()
 			}
 		}
 
@@ -191,8 +190,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
 					.field("service_id", &self.service_id())
-					// TODO: use finish_non_exhaustive when it hits stable
-					.finish()
+					.finish_non_exhaustive()
 			}
 		}
 
@@ -326,8 +324,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
 					.field("service_id", &self.service_id())
-					// TODO: use finish_non_exhaustive when it hits stable
-					.finish()
+					.finish_non_exhaustive()
 			}
 		}
 
@@ -336,8 +333,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
 					.field("service_id", &self.service_id())
-					// TODO: use finish_non_exhaustive when it hits stable
-					.finish()
+					.finish_non_exhaustive()
 			}
 		}
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -257,7 +257,8 @@ impl MessageHeader {
 
 impl<Body> std::fmt::Debug for Message<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		// TODO: use finish_non_exhaustive when it hits stable.
-		f.debug_struct("Message").field("header", &self.header).finish()
+		f.debug_struct("Message")
+			.field("header", &self.header)
+			.finish_non_exhaustive()
 	}
 }

--- a/src/peer_handle.rs
+++ b/src/peer_handle.rs
@@ -217,23 +217,20 @@ impl<Body> PeerCloseHandle<Body> {
 impl<Body> std::fmt::Debug for PeerHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		f.debug_struct(core::any::type_name::<Self>())
-			// TODO: use finish_non_exhaustive when it hits stable
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
 impl<Body> std::fmt::Debug for PeerReadHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		f.debug_struct(core::any::type_name::<Self>())
-			// TODO: use finish_non_exhaustive when it hits stable
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
 impl<Body> std::fmt::Debug for PeerWriteHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		f.debug_struct(core::any::type_name::<Self>())
-			// TODO: use finish_non_exhaustive when it hits stable
-			.finish()
+			.finish_non_exhaustive()
 	}
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -337,41 +337,37 @@ impl<Body> ReceivedRequestWriteHandle<Body> {
 
 impl<Body> std::fmt::Debug for SentRequestHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		// TODO: use finish_non_exhaustive when it hits stable.
 		f.debug_struct("SentRequestHandle")
 			.field("request_id", &self.request_id())
 			.field("service_id", &self.service_id())
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
 impl<Body> std::fmt::Debug for SentRequestWriteHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		// TODO: use finish_non_exhaustive when it hits stable.
 		f.debug_struct("SentRequestWriteHandle")
 			.field("request_id", &self.request_id())
 			.field("service_id", &self.service_id())
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
 impl<Body> std::fmt::Debug for ReceivedRequestHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		// TODO: use finish_non_exhaustive when it hits stable.
 		f.debug_struct("ReceivedRequestHandle")
 			.field("request_id", &self.request_id())
 			.field("service_id", &self.service_id())
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
 impl<Body> std::fmt::Debug for ReceivedRequestWriteHandle<Body> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		// TODO: use finish_non_exhaustive when it hits stable.
 		f.debug_struct("ReceivedRequestWriteHandle")
 			.field("request_id", &self.request_id())
 			.field("service_id", &self.service_id())
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 


### PR DESCRIPTION
This PR makes the `Transport` implementations decide which errors are fatal. The exact rules for when a transport is or is not usable anymore depend on the underlying socket type.

For now, almost all errors remain fatal, to avoid ending up with situations where we continue to use an unusable socket. However, making this change now allows us to change the behavior later without breaking backwards compatibility (the `Transport` trait is public). 