### PR TITLE
revert back to v0.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-# Version 0.6.1 - 2023-03-24
+# Unreleased
 - [add][minor] Add `same_peer` function to `PeerWriteHandle`.
 - [fix][patch] Fix clippy warnings for unnecessary casting.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fizyr-rpc"
 description = "Native Rust implementation of the Fizyr RPC protocol"
-version = "0.6.1"
+version = "0.6.0"
 authors = [
 	"Fizyr B.V. <info@fizyr.com>",
 	"Maarten de Vries <maarten@de-vri.es>",
@@ -29,7 +29,7 @@ byteorder = "1.3.4"
 filedesc = { version = "0.6.0" }
 tokio = { version = "1.0.0", features = ["rt", "sync"] }
 tokio-seqpacket = { version = "0.7.0", optional = true }
-fizyr-rpc-macros = { version = "=0.6.1", path = "macros", optional = true }
+fizyr-rpc-macros = { version = "=0.6.0", path = "macros", optional = true }
 
 [dev-dependencies]
 assert2 = "0.3.3"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fizyr-rpc-macros"
 description = "procedural macros for the fizyr-rpc crate"
-version = "0.6.1"
+version = "0.6.0"
 authors = [
 	"Fizyr B.V. <info@fizyr.com>",
 	"Maarten de Vries <maarten@de-vri.es>",


### PR DESCRIPTION
I am unable to release fizyr_rpc, without being made a repo owner :(

 Luckily, I realized that we don't actually need the unreleased changes yet (I am using `Arc::ptr_eq` instead of `same_peer` now).  This commit is just so that the repo reflects the current state of the published crate.

I suggest that we leave it at `0.6.0` for the time being.