### PR TITLE
Add support for hiding interfaces, services, streams and updates from documentation.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 # Unreleased
+- [change][major] Add `hidden` field to items in interface introspection types.
+- [add][minor] Add `#[hidden]` attribute for interfaces, services, streams and updates in `interface! { ... }` macro.
 - [add][minor] Add asciidoc documentation.
 - [add][minor] Add `same_peer` function to `PeerWriteHandle`.
 - [fix][patch] Fix clippy warnings for unnecessary casting.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ unix-seqpacket = ["tokio-seqpacket"]
 unix-stream = ["tokio/net"]
 
 [dependencies]
-byteorder = "1.3.4"
-filedesc = { version = "0.6.0" }
-tokio = { version = "1.0.0", features = ["rt", "sync"] }
+byteorder = "1.4.3"
+filedesc = { version = "0.6.1" }
+tokio = { version = "1.32.0", features = ["rt", "sync"] }
 tokio-seqpacket = { version = "0.7.0", optional = true }
 fizyr-rpc-macros = { version = "=0.6.0", path = "macros", optional = true }
 
 [dev-dependencies]
-assert2 = "0.3.3"
-clap = { version = "3.1.10", features = ["derive"] }
-tokio = { version = "1.0.0", features = ["macros"] }
+assert2 = "0.3.11"
+clap = { version = "4.4.4", features = ["derive"] }
+tokio = { version = "1.32.0", features = ["macros"] }
 fizyr-rpc = { path = ".", features = ["unix-seqpacket", "unix-stream", "tcp"] }
-memfile = "0.2.0"
+memfile = "0.2.1"
 
 [package.metadata.docs.rs]
 features = ["macros", "tcp", "unix-stream", "unix-seqpacket"]

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -1,7 +1,6 @@
 use fizyr_rpc::TcpPeer;
 
 #[derive(clap::Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 struct Options {
 	#[clap(default_value = "localhost:12345")]
 	address: String,

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -1,7 +1,6 @@
 use fizyr_rpc::TcpListener;
 
 #[derive(clap::Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 struct Options {
 	#[clap(default_value = "[::]:12345")]
 	bind: String,

--- a/examples/unix-seqpacket-client.rs
+++ b/examples/unix-seqpacket-client.rs
@@ -3,7 +3,6 @@ use fizyr_rpc::UnixSeqpacketPeer;
 use std::path::PathBuf;
 
 #[derive(clap::Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 struct Options {
 	socket: PathBuf,
 }

--- a/examples/unix-seqpacket-server.rs
+++ b/examples/unix-seqpacket-server.rs
@@ -2,7 +2,6 @@ use fizyr_rpc::UnixSeqpacketListener;
 use std::path::PathBuf;
 
 #[derive(clap::Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 struct Options {
 	socket: PathBuf,
 }

--- a/examples/unix-stream-client.rs
+++ b/examples/unix-stream-client.rs
@@ -3,7 +3,6 @@ use fizyr_rpc::UnixStreamPeer;
 use std::path::PathBuf;
 
 #[derive(clap::Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 struct Options {
 	socket: PathBuf,
 }

--- a/examples/unix-stream-server.rs
+++ b/examples/unix-stream-server.rs
@@ -2,7 +2,6 @@ use fizyr_rpc::UnixStreamListener;
 use std::path::PathBuf;
 
 #[derive(clap::Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 struct Options {
 	socket: PathBuf,
 }

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -6,10 +6,10 @@ publish = []
 
 [dependencies]
 fizyr-rpc = { path = "..", features = ["macros"]}
-serde = { version = "1.0.126", features = ["derive"] }
-serde_json = "1.0.64"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.107"
 
 [dev-dependencies]
-assert2 = "0.3.5"
+assert2 = "0.3.11"
 fizyr-rpc = { path = "..", features = ["unix-stream"] }
-tokio = { version = "1.0.0", features = ["macros", "net", "rt"] }
+tokio = { version = "1.32.0", features = ["macros", "net", "rt"] }

--- a/macros-tests/src/camera.rs
+++ b/macros-tests/src/camera.rs
@@ -18,6 +18,16 @@ fizyr_rpc::interface! {
 			/// Cancel the recording prematurely.
 			request_update 10 cancel: CancelReason,
 
+			/// Forcibly disconnect during the recording to test error condition.
+			#[hidden]
+			request_update 101 disconnect: (),
+
+			/// Enable tracing for this request.
+			///
+			/// The server will start sending tracing updates.
+			#[hidden]
+			request_update 102 enable_tracing: (),
+
 			/// Update sent by the server to notify the client about recording progress.
 			///
 			/// When the record state goes to `RecordState::Processing`,
@@ -28,7 +38,19 @@ fizyr_rpc::interface! {
 			///
 			/// The camera may send multiple image updates depending on the configuration.
 			response_update 12 image: Image,
+
+			/// Update with tracing information.
+			///
+			/// Only sent if you send a `enable_tracing` request update.
+			#[hidden]
+			response_update 202 tracing: Tracing,
 		},
+
+		#[hidden]
+		service 2 hidden_service: () -> (),
+
+		#[hidden]
+		stream 3 hidden_stream: (),
 	}
 }
 
@@ -66,4 +88,9 @@ pub struct Image {
 	pub height: u32,
 	pub format: u32,
 	pub data: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Tracing {
+	pub message: String,
 }

--- a/macros-tests/tests/camera.rs
+++ b/macros-tests/tests/camera.rs
@@ -145,7 +145,7 @@ fn interface_introspection_camera() {
 		"or even a line scanner.\n",
 	));
 
-	assert!(interface.services.len() == 2);
+	assert!(interface.services.len() == 3);
 
 	assert!(interface.services[0].name == "ping");
 	assert!(interface.services[0].service_id == 0);
@@ -155,6 +155,7 @@ fn interface_introspection_camera() {
 		"A succesful ping indicates that the server is running,\n",
 		"but it does not guarantee that it is connected to a camera.\n",
 	));
+	assert!(interface.services[0].hidden == false);
 	assert!(interface.services[0].request_body == "()");
 	assert!(interface.services[0].response_body == "()");
 	assert!(interface.services[0].request_updates.len() == 0);
@@ -163,15 +164,34 @@ fn interface_introspection_camera() {
 	assert!(interface.services[1].name == "record");
 	assert!(interface.services[1].service_id == 1);
 	assert!(interface.services[1].doc == "Record an image.\n");
+	assert!(interface.services[1].hidden == false);
 	assert!(interface.services[1].request_body == "macros_tests::camera::RecordRequest");
 	assert!(interface.services[1].response_body == "()");
-	assert!(interface.services[1].request_updates.len() == 1);
+	assert!(interface.services[1].request_updates.len() == 3);
+
 	assert!(interface.services[1].request_updates[0].name == "cancel");
 	assert!(interface.services[1].request_updates[0].doc == "Cancel the recording prematurely.\n");
+	assert!(interface.services[1].request_updates[0].hidden == false);
 	assert!(interface.services[1].request_updates[0].service_id == 10);
 	assert!(interface.services[1].request_updates[0].body == "macros_tests::camera::CancelReason");
 
-	assert!(interface.services[1].response_updates.len() == 2);
+	assert!(interface.services[1].request_updates[1].name == "disconnect");
+	assert!(interface.services[1].request_updates[1].doc == "Forcibly disconnect during the recording to test error condition.\n");
+	assert!(interface.services[1].request_updates[1].hidden == true);
+	assert!(interface.services[1].request_updates[1].service_id == 101);
+	assert!(interface.services[1].request_updates[1].body == "()");
+
+	assert!(interface.services[1].request_updates[2].name == "enable_tracing");
+	assert!(interface.services[1].request_updates[2].doc == concat!(
+		"Enable tracing for this request.\n",
+		"\n",
+		"The server will start sending tracing updates.\n",
+	));
+	assert!(interface.services[1].request_updates[2].hidden == true);
+	assert!(interface.services[1].request_updates[2].service_id == 102);
+	assert!(interface.services[1].request_updates[2].body == "()");
+
+	assert!(interface.services[1].response_updates.len() == 3);
 	assert!(interface.services[1].response_updates[0].name == "state");
 	assert!(interface.services[1].response_updates[0].doc == concat!(
 		"Update sent by the server to notify the client about recording progress.\n",
@@ -179,6 +199,7 @@ fn interface_introspection_camera() {
 		"When the record state goes to `RecordState::Processing`,\n",
 		"the camera field of view may be obstructed by a robot again.\n",
 	));
+	assert!(interface.services[1].response_updates[0].hidden == false);
 	assert!(interface.services[1].response_updates[0].service_id == 11);
 	assert!(interface.services[1].response_updates[0].body == "macros_tests::camera::RecordState");
 
@@ -188,8 +209,45 @@ fn interface_introspection_camera() {
 			"\n",
 			"The camera may send multiple image updates depending on the configuration.\n",
 	));
+	assert!(interface.services[1].response_updates[1].hidden == false);
 	assert!(interface.services[1].response_updates[1].service_id == 12);
 	assert!(interface.services[1].response_updates[1].body == "macros_tests::camera::Image");
+
+	assert!(interface.services[1].response_updates[2].name == "tracing");
+	assert!(interface.services[1].response_updates[2].doc == concat!(
+			"Update with tracing information.\n",
+			"\n",
+			"Only sent if you send a `enable_tracing` request update.\n",
+	));
+	assert!(interface.services[1].response_updates[2].hidden == true);
+	assert!(interface.services[1].response_updates[2].service_id == 202);
+	assert!(interface.services[1].response_updates[2].body == "macros_tests::camera::Tracing");
+
+	assert!(interface.services[2].name == "hidden_service");
+	assert!(interface.services[2].service_id == 2);
+	assert!(interface.services[2].doc == "");
+	assert!(interface.services[2].hidden == true);
+	assert!(interface.services[2].request_body == "()");
+	assert!(interface.services[2].response_body == "()");
+	assert!(interface.services[2].request_updates.len() == 0);
+	assert!(interface.services[2].response_updates.len() == 0);
+
+	assert!(interface.services[2].name == "hidden_service");
+	assert!(interface.services[2].service_id == 2);
+	assert!(interface.services[2].doc == "");
+	assert!(interface.services[2].hidden == true);
+	assert!(interface.services[2].request_body == "()");
+	assert!(interface.services[2].response_body == "()");
+	assert!(interface.services[2].request_updates.len() == 0);
+	assert!(interface.services[2].response_updates.len() == 0);
+
+	assert!(interface.streams.len() == 1);
+
+	assert!(interface.streams[0].name == "hidden_stream");
+	assert!(interface.streams[0].doc == "");
+	assert!(interface.streams[0].hidden == true);
+	assert!(interface.streams[0].service_id == 3);
+	assert!(interface.streams[0].body == "()");
 }
 
 #[test]
@@ -204,6 +262,7 @@ fn interface_introspection_camera_events() {
 
 	assert!(interface.streams[0].name == "record_state");
 	assert!(interface.streams[0].doc == "Notifications whenever the camera changes record state.\n");
+	assert!(interface.streams[0].hidden == false);
 	assert!(interface.streams[0].service_id == 11);
 	assert!(interface.streams[0].body == "macros_tests::camera::RecordState");
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,6 +16,6 @@ edition = "2021"
 proc_macro = true
 
 [dependencies]
-syn = { version = "1.0.72", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }
-proc-macro2 = "1.0.26"
-quote = "1.0.9"
+syn = { version = "2.0.37", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }
+proc-macro2 = "1.0.67"
+quote = "1.0.33"

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -11,7 +11,16 @@
 pub mod cooked {
 	use crate::util::{parse_doc_attr_contents, WithSpan};
 	use proc_macro2::Span;
+	use syn::spanned::Spanned;
 	use super::raw;
+
+	/// Marker to indicate an item should be hidden.
+	#[derive(Copy, Clone)]
+	pub struct Hidden {
+		/// The span of the #[hidden] attribute.
+		#[allow(unused)]
+		span: Span,
+	}
 
 	/// A parsed interface definition.
 	pub struct InterfaceDefinition {
@@ -23,6 +32,9 @@ pub mod cooked {
 
 		/// The doc comments of the interface.
 		doc: Vec<WithSpan<String>>,
+
+		/// If set, the interface should be hidden from documentation.
+		hidden: Option<Hidden>,
 
 		/// The services in the interface.
 		services: Vec<ServiceDefinition>,
@@ -41,6 +53,9 @@ pub mod cooked {
 
 		/// The doc comments of the service.
 		doc: Vec<WithSpan<String>>,
+
+		/// If set, the service should be hidden from documentation.
+		hidden: Option<Hidden>,
 
 		/// The type of the request body.
 		request_type: Box<syn::Type>,
@@ -66,6 +81,9 @@ pub mod cooked {
 		/// The doc comments of the update.
 		doc: Vec<WithSpan<String>>,
 
+		/// If set, the update should be hidden from documentation.
+		hidden: Option<Hidden>,
+
 		/// The body type of the update.
 		body_type: Box<syn::Type>,
 	}
@@ -80,6 +98,9 @@ pub mod cooked {
 
 		/// The doc comments of the stream.
 		doc: Vec<WithSpan<String>>,
+
+		/// If set, the stream should be hidden from documentation.
+		hidden: Option<Hidden>,
 
 		/// The body type of the stream message.
 		body_type: Box<syn::Type>,
@@ -98,13 +119,17 @@ pub mod cooked {
 		/// The doc comments of the message.
 		fn doc(&self) -> &[WithSpan<String>];
 
+		/// Check if the message should be hidden from generated documentation.
+		fn hidden(&self) -> Option<Hidden>;
+
 		/// The type of the message body.
 		fn body_type(&self) -> &syn::Type;
 	}
 
 	/// Attributes that include only doc comments.
-	struct DocOnlyAttributes {
+	struct Attributes {
 		doc: Vec<WithSpan<String>>,
+		hidden: Option<Hidden>,
 	}
 
 	impl InterfaceDefinition {
@@ -123,6 +148,11 @@ pub mod cooked {
 			&self.doc
 		}
 
+		/// Check if the interface should be hidden from generated documentation.
+		pub fn hidden(&self) -> Option<Hidden> {
+			self.hidden
+		}
+
 		/// Get the list of services in the interface.
 		pub fn services(&self) -> &[ServiceDefinition] {
 			&self.services
@@ -135,7 +165,7 @@ pub mod cooked {
 
 		/// Process a raw interface definition into a cooked one.
 		pub fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::InterfaceDefinition) -> Self {
-			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+			let attrs = Attributes::from_raw(errors, raw.attrs);
 			let mut services = Vec::new();
 			let mut streams = Vec::new();
 			for item in raw.items {
@@ -186,6 +216,7 @@ pub mod cooked {
 				visibility: raw.visibility,
 				name: raw.name,
 				doc: attrs.doc,
+				hidden: attrs.hidden,
 				services,
 				streams,
 			}
@@ -206,6 +237,11 @@ pub mod cooked {
 		/// Get the doc comments of the service.
 		pub fn doc(&self) -> &[WithSpan<String>] {
 			&self.doc
+		}
+
+		/// Check if the service should be hidden from generated documentation.
+		pub fn hidden(&self) -> Option<Hidden> {
+			self.hidden
 		}
 
 		/// Get the type of the request body.
@@ -230,7 +266,7 @@ pub mod cooked {
 
 		/// Process a raw service definition into a cooked one.
 		fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::ServiceDefinition) -> Self {
-			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+			let attrs = Attributes::from_raw(errors, raw.attrs);
 			let mut request_updates = Vec::new();
 			let mut response_updates = Vec::new();
 			if let raw::MaybeServiceBody::Body(body, _) = raw.body {
@@ -283,6 +319,7 @@ pub mod cooked {
 				service_id: parse_i32(errors, raw.service_id),
 				name: raw.name,
 				doc: attrs.doc,
+				hidden: attrs.hidden,
 				request_type: raw.request_type,
 				response_type: raw.response_type,
 				request_updates,
@@ -307,6 +344,11 @@ pub mod cooked {
 			&self.doc
 		}
 
+		/// Check if the update should be hidden from generated documentation.
+		pub fn hidden(&self) -> Option<Hidden> {
+			self.hidden
+		}
+
 		/// Get the type of the update body.
 		pub fn body_type(&self) -> &syn::Type {
 			&self.body_type
@@ -314,12 +356,13 @@ pub mod cooked {
 
 		/// Process a raw update definition into a cooked one.
 		fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::UpdateDefinition) -> (raw::UpdateKind, Self) {
-			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+			let attrs = Attributes::from_raw(errors, raw.attrs);
 
 			(raw.kind, Self {
 				service_id: parse_i32(errors, raw.service_id),
 				name: raw.name,
 				doc: attrs.doc,
+				hidden: attrs.hidden,
 				body_type: raw.body_type,
 			})
 		}
@@ -341,6 +384,11 @@ pub mod cooked {
 			&self.doc
 		}
 
+		/// Check if the stream should be hidden from generated documentation.
+		pub fn hidden(&self) -> Option<Hidden> {
+			self.hidden
+		}
+
 		/// Get the type of the stream body.
 		pub fn body_type(&self) -> &syn::Type {
 			self.body_type.as_ref()
@@ -348,22 +396,24 @@ pub mod cooked {
 
 		/// Process a raw stream definition into a cooked one.
 		fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::StreamDefinition) -> Self {
-			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+			let attrs = Attributes::from_raw(errors, raw.attrs);
 
 			Self {
 				service_id: parse_i32(errors, raw.service_id),
 				name: raw.name,
 				doc: attrs.doc,
+				hidden: attrs.hidden,
 				body_type: raw.body_type,
 			}
 		}
 	}
 
 
-	impl DocOnlyAttributes {
+	impl Attributes {
 		/// Process raw attributes into cooked DocOnlyAttributes.
 		fn from_raw(errors: &mut Vec<syn::Error>, attrs: Vec<syn::Attribute>) -> Self {
 			let mut doc = Vec::new();
+			let mut hidden = None;
 
 			for attr in attrs {
 				if attr.path().is_ident("doc") {
@@ -371,12 +421,18 @@ pub mod cooked {
 						Ok(x) => doc.push(x),
 						Err(e) => errors.push(e),
 					}
+				} else if attr.path().is_ident("hidden") {
+					if let Err(e) = attr.meta.require_path_only() {
+						errors.push(e);
+					} else {
+						hidden = Some(Hidden { span: attr.path().span() });
+					}
 				} else {
 					errors.push(syn::Error::new_spanned(attr.path(), "unknown attribute"));
 				}
 			}
 
-			Self { doc }
+			Self { doc, hidden }
 		}
 	}
 
@@ -404,6 +460,10 @@ pub mod cooked {
 			self.doc()
 		}
 
+		fn hidden(&self) -> Option<Hidden> {
+			self.hidden
+		}
+
 		fn body_type(&self) -> &syn::Type {
 			self.body_type()
 		}
@@ -422,6 +482,10 @@ pub mod cooked {
 			self.doc()
 		}
 
+		fn hidden(&self) -> Option<Hidden> {
+			self.hidden
+		}
+
 		fn body_type(&self) -> &syn::Type {
 			self.body_type()
 		}
@@ -433,12 +497,13 @@ pub mod cooked {
 /// The types in this modules still contain potentially invalid data.
 /// We want to fully parse this raw form before continuing to more detailed error checking.
 pub mod raw {
-	mod keyword {
+	pub mod keyword {
 		syn::custom_keyword!(interface);
 		syn::custom_keyword!(service);
 		syn::custom_keyword!(request_update);
 		syn::custom_keyword!(response_update);
 		syn::custom_keyword!(stream);
+		syn::custom_keyword!(hidden);
 	}
 
 	pub struct InterfaceInput {

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -366,13 +366,13 @@ pub mod cooked {
 			let mut doc = Vec::new();
 
 			for attr in attrs {
-				if attr.path.is_ident("doc") {
-					match parse_doc_attr_contents(attr.tokens) {
+				if attr.path().is_ident("doc") {
+					match parse_doc_attr_contents(attr) {
 						Ok(x) => doc.push(x),
 						Err(e) => errors.push(e),
 					}
 				} else {
-					errors.push(syn::Error::new_spanned(attr.path, "unknown attribute"));
+					errors.push(syn::Error::new_spanned(attr.path(), "unknown attribute"));
 				}
 			}
 

--- a/src/introspection.rs
+++ b/src/introspection.rs
@@ -15,6 +15,9 @@ pub struct InterfaceDefinition<TypeInfo> {
 	/// This string may contain rustdoc compatible markup.
 	pub doc: String,
 
+	/// If true, the item should be hidden from documentation by default.
+	pub hidden: bool,
+
 	/// The list of services in the interface.
 	pub services: Vec<ServiceDefinition<TypeInfo>>,
 
@@ -32,6 +35,9 @@ pub struct ServiceDefinition<TypeInfo> {
 	///
 	/// This string may contain rustdoc compatible markup.
 	pub doc: String,
+
+	/// If true, the item should be hidden from documentation by default.
+	pub hidden: bool,
 
 	/// The service ID of the service.
 	pub service_id: i32,
@@ -60,6 +66,9 @@ pub struct UpdateDefinition<TypeInfo> {
 	/// This string may contain rustdoc compatible markup.
 	pub doc: String,
 
+	/// If true, the item should be hidden from documentation by default.
+	pub hidden: bool,
+
 	/// The service ID of the update message.
 	pub service_id: i32,
 
@@ -77,6 +86,9 @@ pub struct StreamDefinition<TypeInfo> {
 	///
 	/// This string may contain rustdoc compatible markup.
 	pub doc: String,
+
+	/// If true, the item should be hidden from documentation by default.
+	pub hidden: bool,
 
 	/// The service ID of the stream message.
 	pub service_id: i32,


### PR DESCRIPTION
This PR adds a `#[hidden]` attribute for use within the `interface! { ... }` macro.

It is exposed as a new field on the different introspection types.

Sadly that makes it a breaking change, because it's adding a new public field to the structs.